### PR TITLE
Short-circuit entity extraction glean loop when completion is detected

### DIFF
--- a/nano_graphrag/_op.py
+++ b/nano_graphrag/_op.py
@@ -311,26 +311,38 @@ async def extract_entities(
         chunk_key = chunk_key_dp[0]
         chunk_dp = chunk_key_dp[1]
         content = chunk_dp["content"]
+        completion_delimiter = context_base["completion_delimiter"]
         hint_prompt = entity_extract_prompt.format(**context_base, input_text=content)
         final_result = await use_llm_func(hint_prompt)
         if isinstance(final_result, list):
             final_result = final_result[0]["text"]
 
-        history = pack_user_ass_to_openai_messages(hint_prompt, final_result, using_amazon_bedrock)
-        for now_glean_index in range(entity_extract_max_gleaning):
-            glean_result = await use_llm_func(continue_prompt, history_messages=history)
-
-            history += pack_user_ass_to_openai_messages(continue_prompt, glean_result, using_amazon_bedrock)
-            final_result += glean_result
-            if now_glean_index == entity_extract_max_gleaning - 1:
-                break
-
-            if_loop_result: str = await use_llm_func(
-                if_loop_prompt, history_messages=history
+        if completion_delimiter not in final_result:
+            history = pack_user_ass_to_openai_messages(
+                hint_prompt, final_result, using_amazon_bedrock
             )
-            if_loop_result = if_loop_result.strip().strip('"').strip("'").lower()
-            if if_loop_result != "yes":
-                break
+            for now_glean_index in range(entity_extract_max_gleaning):
+                glean_result = await use_llm_func(
+                    continue_prompt, history_messages=history
+                )
+
+                history += pack_user_ass_to_openai_messages(
+                    continue_prompt, glean_result, using_amazon_bedrock
+                )
+                final_result += glean_result
+
+                if completion_delimiter in final_result:
+                    break
+
+                if now_glean_index == entity_extract_max_gleaning - 1:
+                    break
+
+                if_loop_result: str = await use_llm_func(
+                    if_loop_prompt, history_messages=history
+                )
+                if_loop_result = if_loop_result.strip().strip('\"').strip("'").lower()
+                if if_loop_result != "yes":
+                    break
 
         records = split_string_by_multi_markers(
             final_result,

--- a/tests/entity_extraction/test_extract.py
+++ b/tests/entity_extraction/test_extract.py
@@ -2,7 +2,13 @@ import pytest
 import dspy
 from openai import BadRequestError
 from unittest.mock import Mock, patch, AsyncMock
+import sys
+from types import SimpleNamespace
+
+sys.modules.setdefault("transformers", SimpleNamespace(AutoTokenizer=Mock()))
 from nano_graphrag.entity_extraction.extract import generate_dataset, extract_entities_dspy
+from nano_graphrag._op import extract_entities
+from nano_graphrag.prompt import PROMPTS
 from nano_graphrag.base import TextChunkSchema, BaseGraphStorage, BaseVectorStorage
 import httpx
 
@@ -132,6 +138,50 @@ async def test_generate_dataset_with_bad_request_error():
     assert len(result) == 0
     mock_to_thread.assert_called_once()
 
+
+@pytest.mark.asyncio
+async def test_extract_entities_stops_after_completion_delimiter():
+    chunks = {
+        "chunk1": TextChunkSchema(content="Some content for extraction"),
+    }
+    mock_graph_storage = Mock(spec=BaseGraphStorage)
+    tokenizer_wrapper = Mock()
+    completion_delimiter = PROMPTS["DEFAULT_COMPLETION_DELIMITER"]
+    tuple_delimiter = PROMPTS["DEFAULT_TUPLE_DELIMITER"]
+    final_response = (
+        f"(\"entity\"{tuple_delimiter}\"Apple\"{tuple_delimiter}"
+        f"\"ORGANIZATION\"{tuple_delimiter}\"A tech company\"){completion_delimiter}"
+    )
+
+    llm_mock = AsyncMock(return_value=final_response)
+    global_config = {
+        "best_model_func": llm_mock,
+        "entity_extract_max_gleaning": 2,
+    }
+
+    with patch(
+        "nano_graphrag._op._merge_nodes_then_upsert", new_callable=AsyncMock
+    ) as mock_merge_nodes, patch(
+        "nano_graphrag._op._merge_edges_then_upsert", new_callable=AsyncMock
+    ) as mock_merge_edges:
+        mock_merge_nodes.return_value = {
+            "entity_name": "APPLE",
+            "description": "A tech company",
+        }
+
+        result = await extract_entities(
+            chunks,
+            mock_graph_storage,
+            entity_vdb=None,
+            tokenizer_wrapper=tokenizer_wrapper,
+            global_config=global_config,
+        )
+
+    assert result == mock_graph_storage
+    assert llm_mock.await_count == 1
+    assert all("history_messages" not in call.kwargs for call in llm_mock.await_args_list)
+    mock_merge_nodes.assert_awaited_once()
+    assert mock_merge_edges.await_count == 0
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_compiled,entity_vdb", [


### PR DESCRIPTION
## Summary
- short-circuit entity extraction glean loop when the initial response already includes the completion delimiter
- break out of the glean loop as soon as the delimiter appears to avoid the expensive follow-up prompt
- add a unit test that stubs the LLM to return a delimited response immediately and ensures no continuation calls are made, including a lightweight transformers stub for test imports

## Testing
- pytest tests/entity_extraction/test_extract.py

------
https://chatgpt.com/codex/tasks/task_e_68d007f7397c832fa21dc30476c3bf4b